### PR TITLE
Fix buildroot OpenSBI ISA selection

### DIFF
--- a/buildroot/package/opensbi/opensbi.mk
+++ b/buildroot/package/opensbi/opensbi.mk
@@ -1,0 +1,16 @@
+ifeq ($(BR2_TARGET_OPENSBI),y)
+ifeq ($(BR2_riscv),y)
+
+OPENSBI_USER_VARS := $(call qstrip,$(BR2_TARGET_OPENSBI_ADDITIONAL_VARIABLES))
+
+# Preserve explicit user override from OpenSBI "Additional build variables".
+ifeq ($(filter PLATFORM_RISCV_ISA=%,$(OPENSBI_USER_VARS)),)
+OPENSBI_MAKE_ENV += PLATFORM_RISCV_ISA=$(GCC_TARGET_ARCH)
+endif
+
+ifeq ($(filter PLATFORM_RISCV_ABI=%,$(OPENSBI_USER_VARS)),)
+OPENSBI_MAKE_ENV += PLATFORM_RISCV_ABI=$(BR2_GCC_TARGET_ABI)
+endif
+
+endif
+endif


### PR DESCRIPTION
The current buildroot use wrong ISA for OpenSBI, fix it.
For SpinalHDL/VexiiRiscv#120